### PR TITLE
build: add Windows-specific dependencies

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -23,6 +23,7 @@ dirs = "6.0.0"
 flate2 = "1.1.0"
 tar = "0.4.44"
 cfg-if = "1.0.0"
+[target.'cfg(windows)'.dependencies]
 winreg = "0.55.0"
 winapi = { version = "0.3", features = ["winuser"] }
 tempfile = "3.19.1"


### PR DESCRIPTION
Add winreg, winapi, and tempfile dependencies for Windows platform to ensure compatibility and functionality on Windows systems.