### PR TITLE
[workflows]: fix actions and make them execute on every commit.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,10 +89,10 @@ jobs:
           path: artifacts
       - name: Archive artifacts
         run: |
-          tar -czvf synthlauncher-linux-x64.tar.gz artifacts/synthlauncher-linux-x64/*
-          tar -czvf synthlauncher-macos-arm.tar.gz artifacts/synthlauncher-macos-arm/*
-          tar -czvf synthlauncher-macos-x64.tar.gz artifacts/synthlauncher-macos-x64/*
-          tar -czvf synthlauncher-windows-x64.tar.gz artifacts/synthlauncher-windows-x64/*
+          tar -czvf synthlauncher-linux-x64.tar.gz -C artifacts/synthlauncher-linux-x64 *
+          tar -czvf synthlauncher-macos-arm.tar.gz -C artifacts/synthlauncher-macos-arm *
+          tar -czvf synthlauncher-macos-x64.tar.gz -C artifacts/synthlauncher-macos-x64 *
+          tar -czvf synthlauncher-windows-x64.tar.gz -C artifacts/synthlauncher-windows-x64 *
       - name: Create Release
         uses: ncipollo/release-action@v1
         if: startsWith(github.ref, 'refs/tags/') # Only run on tag pushes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,10 +89,10 @@ jobs:
           path: artifacts
       - name: Archive artifacts
         run: |
-          tar -czvf synthlauncher-linux-x64.tar.gz -C artifacts/synthlauncher-linux-x64 *
-          tar -czvf synthlauncher-macos-arm.tar.gz -C artifacts/synthlauncher-macos-arm *
-          tar -czvf synthlauncher-macos-x64.tar.gz -C artifacts/synthlauncher-macos-x64 *
-          tar -czvf synthlauncher-windows-x64.tar.gz -C artifacts/synthlauncher-windows-x64 *
+          cd artifacts/synthlauncher-linux-x64 && tar -czvf ../synthlauncher-linux-x64.tar.gz *
+          cd artifacts/synthlauncher-macos-arm && tar -czvf ../synthlauncher-macos-arm.tar.gz *
+          cd artifacts/synthlauncher-macos-x64 && tar -czvf ../synthlauncher-macos-x64.tar.gz *
+          cd artifacts/synthlauncher-windows-x64 && tar -czvf ../synthlauncher-windows-x64.tar.gz *
       - name: Create Release
         uses: ncipollo/release-action@v1
         if: startsWith(github.ref, 'refs/tags/') # Only run on tag pushes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*" # Trigger on version tags (e.g., v1.0.0)
+    branches:
+      - "*"
   workflow_dispatch: # Allow manual triggering
 
 env:
@@ -26,14 +28,14 @@ jobs:
           - os: windows-latest
             artifact_name: windows-x64
             target: x86_64-pc-windows-msvc
-    
+
     name: Build (${{ matrix.artifact_name }})
     runs-on: ${{ matrix.os }}
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -41,22 +43,22 @@ jobs:
           target: ${{ matrix.target }}
           profile: minimal
           override: true
-      
+
       - name: Install OpenSSL (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev
-      
+
       - name: Install OpenSSL (macOS)
         if: matrix.os == 'macos-latest'
         run: |
           brew install openssl@3
           echo "OPENSSL_DIR=$(brew --prefix openssl@3)" >> $GITHUB_ENV
-      
+
       - name: Build (Release)
         run: cargo build --release --target ${{ matrix.target }}
-      
+
       - name: Package binary
         shell: bash
         run: |
@@ -66,42 +68,39 @@ jobs:
           else
             cp target/${{ matrix.target }}/release/synthlauncher release/
           fi
-      
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: synthlauncher-${{ matrix.artifact_name }}
           path: release/
-  
+
   release:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # Explicitly grant permission to create releases
-    
+      contents: write # Explicitly grant permission to create releases
+
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-      
+
       - name: Create Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')  # Only run on tag pushes
+        uses: ncipollo/release-action@v1
+        if: startsWith(github.ref, 'refs/tags/') # Only run on tag pushes
         with:
           # tag_name will be automatically determined from the git tag
-          name: SynthLauncher ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           body: |
             **SynthLauncher** ${{ github.ref_name }}
             - Built for Windows, macOS, and Linux
             - Commit: [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
-          draft: false
-          prerelease: false
-          files: |
-            artifacts/synthlauncher-linux-x64/synthlauncher
-            artifacts/synthlauncher-macos-arm/synthlauncher
-            artifacts/synthlauncher-macos-x64/synthlauncher
-            artifacts/synthlauncher-windows-x64/synthlauncher.exe
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: ${{ endsWith(github.ref_name, '-dev') }}
+          artifacts: |
+            artifacts/synthlauncher-linux-x64
+            artifacts/synthlauncher-macos-arm
+            artifacts/synthlauncher-macos-x64
+            artifacts/synthlauncher-windows-x64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-
+      - name: Archive artifacts
+        run: |
+          tar -czvf synthlauncher-linux-x64.tar.gz artifacts/synthlauncher-linux-x64/*
+          tar -czvf synthlauncher-macos-arm.tar.gz artifacts/synthlauncher-macos-arm/*
+          tar -czvf synthlauncher-macos-x64.tar.gz artifacts/synthlauncher-macos-x64/*
+          tar -czvf synthlauncher-windows-x64.tar.gz artifacts/synthlauncher-windows-x64/*
       - name: Create Release
         uses: ncipollo/release-action@v1
         if: startsWith(github.ref, 'refs/tags/') # Only run on tag pushes
@@ -100,7 +105,7 @@ jobs:
             - Commit: [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
           prerelease: ${{ endsWith(github.ref_name, '-dev') }}
           artifacts: |
-            artifacts/synthlauncher-linux-x64
-            artifacts/synthlauncher-macos-arm
-            artifacts/synthlauncher-macos-x64
-            artifacts/synthlauncher-windows-x64
+            synthlauncher-linux-x64.tar.gz
+            synthlauncher-macos-arm.tar.gz
+            synthlauncher-macos-x64.tar.gz
+            synthlauncher-windows-x64.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,10 +89,10 @@ jobs:
           path: artifacts
       - name: Archive artifacts
         run: |
-          cd artifacts/synthlauncher-linux-x64 && tar -czvf ../synthlauncher-linux-x64.tar.gz *
-          cd artifacts/synthlauncher-macos-arm && tar -czvf ../synthlauncher-macos-arm.tar.gz *
-          cd artifacts/synthlauncher-macos-x64 && tar -czvf ../synthlauncher-macos-x64.tar.gz *
-          cd artifacts/synthlauncher-windows-x64 && tar -czvf ../synthlauncher-windows-x64.tar.gz *
+          cd /artifacts/synthlauncher-linux-x64 && tar -czvf ../synthlauncher-linux-x64.tar.gz *
+          cd /artifacts/synthlauncher-macos-arm && tar -czvf ../synthlauncher-macos-arm.tar.gz *
+          cd /artifacts/synthlauncher-macos-x64 && tar -czvf ../synthlauncher-macos-x64.tar.gz *
+          cd /artifacts/synthlauncher-windows-x64 && tar -czvf ../synthlauncher-windows-x64.tar.gz *
       - name: Create Release
         uses: ncipollo/release-action@v1
         if: startsWith(github.ref, 'refs/tags/') # Only run on tag pushes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,12 +87,17 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
+      - name: Display artifacts
+        run: |
+          ls -l
+          ls -l /
+          ls -l artifacts
       - name: Archive artifacts
         run: |
-          cd /artifacts/synthlauncher-linux-x64 && tar -czvf ../synthlauncher-linux-x64.tar.gz *
-          cd /artifacts/synthlauncher-macos-arm && tar -czvf ../synthlauncher-macos-arm.tar.gz *
-          cd /artifacts/synthlauncher-macos-x64 && tar -czvf ../synthlauncher-macos-x64.tar.gz *
-          cd /artifacts/synthlauncher-windows-x64 && tar -czvf ../synthlauncher-windows-x64.tar.gz *
+          cd artifacts/synthlauncher-linux-x64/ && tar -czvf ../../synthlauncher-linux-x64.tar.gz *
+          cd artifacts/synthlauncher-macos-arm/ && tar -czvf ../../synthlauncher-macos-arm.tar.gz *
+          cd artifacts/synthlauncher-macos-x64/ && tar -czvf ../../synthlauncher-macos-x64.tar.gz *
+          cd artifacts/synthlauncher-windows-x64/ && tar -czvf ../../synthlauncher-windows-x64.tar.gz *
       - name: Create Release
         uses: ncipollo/release-action@v1
         if: startsWith(github.ref, 'refs/tags/') # Only run on tag pushes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,9 +96,9 @@ jobs:
         working-directory: ./artifacts
         run: |
           cd synthlauncher-linux-x64/ && tar -czvf ../synthlauncher-linux-x64.tar.gz *
-          cd synthlauncher-macos-arm/ && tar -czvf ../synthlauncher-macos-arm.tar.gz *
-          cd synthlauncher-macos-x64/ && tar -czvf ../synthlauncher-macos-x64.tar.gz *
-          cd synthlauncher-windows-x64/ && tar -czvf ../synthlauncher-windows-x64.tar.gz *
+          cd ../synthlauncher-macos-arm/ && tar -czvf ../synthlauncher-macos-arm.tar.gz *
+          cd ../synthlauncher-macos-x64/ && tar -czvf ../synthlauncher-macos-x64.tar.gz *
+          cd ../synthlauncher-windows-x64/ && tar -czvf ../synthlauncher-windows-x64.tar.gz *
       - name: Create Release
         uses: ncipollo/release-action@v1
         if: startsWith(github.ref, 'refs/tags/') # Only run on tag pushes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,11 +93,12 @@ jobs:
           ls -l /
           ls -l artifacts
       - name: Archive artifacts
+        working-directory: ./artifacts
         run: |
-          cd artifacts/synthlauncher-linux-x64/ && tar -czvf ../../synthlauncher-linux-x64.tar.gz *
-          cd artifacts/synthlauncher-macos-arm/ && tar -czvf ../../synthlauncher-macos-arm.tar.gz *
-          cd artifacts/synthlauncher-macos-x64/ && tar -czvf ../../synthlauncher-macos-x64.tar.gz *
-          cd artifacts/synthlauncher-windows-x64/ && tar -czvf ../../synthlauncher-windows-x64.tar.gz *
+          cd synthlauncher-linux-x64/ && tar -czvf ../synthlauncher-linux-x64.tar.gz *
+          cd synthlauncher-macos-arm/ && tar -czvf ../synthlauncher-macos-arm.tar.gz *
+          cd synthlauncher-macos-x64/ && tar -czvf ../synthlauncher-macos-x64.tar.gz *
+          cd synthlauncher-windows-x64/ && tar -czvf ../synthlauncher-windows-x64.tar.gz *
       - name: Create Release
         uses: ncipollo/release-action@v1
         if: startsWith(github.ref, 'refs/tags/') # Only run on tag pushes
@@ -110,7 +111,7 @@ jobs:
             - Commit: [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
           prerelease: ${{ endsWith(github.ref_name, '-dev') }}
           artifacts: |
-            synthlauncher-linux-x64.tar.gz
-            synthlauncher-macos-arm.tar.gz
-            synthlauncher-macos-x64.tar.gz
-            synthlauncher-windows-x64.tar.gz
+            artifacts/synthlauncher-linux-x64.tar.gz
+            artifacts/synthlauncher-macos-arm.tar.gz
+            artifacts/synthlauncher-macos-x64.tar.gz
+            artifacts/synthlauncher-windows-x64.tar.gz


### PR DESCRIPTION
fixed actions creating release failing, and made it so it builds on every commit now you can ensure whether or not a commit builds (it doesn't release except on tags)

to create a release run:
```
# replace v0.1.0 with any other version it must not repeat and it must start with a v
git tag -a v0.1.0 -m "some tag message"
git push --tags
```

to create a pre-release run:
```
# replace v0.1.0 with any other version it must not repeat and it must start with a v, and must end with a `-dev`
git tag -a v0.1.0-dev -m "some tag message"
git push --tags
```

otherwise you have the build artifacts on every commit.