### PR TITLE
Fix lifetime warning in builder()

### DIFF
--- a/crates/sl-utils/src/requester.rs
+++ b/crates/sl-utils/src/requester.rs
@@ -74,7 +74,7 @@ impl Requester {
         }
     }
 
-    pub fn builder(&self) -> RequestBuilder {
+    pub fn builder(&self) -> RequestBuilder<'_> {
         RequestBuilder::new(&self)
     }
 


### PR DESCRIPTION
fixes lifetime warning in sl-utils when compiling:

<img width="979" height="347" alt="scrn-2025-08-06-23-36-31" src="https://github.com/user-attachments/assets/7af574a1-d1dd-4795-a72d-dd40f9ea4f59" />